### PR TITLE
New config structure :whale:

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,55 +17,7 @@ import defaults from './configDefaults';
  */
 let rewrites = {
 
-	googleAnalyticsId: 'UA-XXXXX-X',
-
-	// todo documentation
-	// don't forget leading slash. like this: /backoffice
-	publicPath: "/backoffice",
-	serverPort: 5000,
-
-	/**
-	 * backend API config
-	 */
-	apiProtocol: "http://",
-	apiHost: "localhost", //host + port
-	apiPath: "/backend",
-
-	/**
-	 * other Panther components' location
-	 */
-	//address: host + port + base path
-	geonodeProtocol: "http://",
-	geonodeAddress: "localhost",
-
-	geoserverProtocol: "http://",
-	geoserverAddress: "localhost/geoserver",
-
-	frontOfficeProtocol: "http://",
-	frontOfficeAddress: "localhost",
-	frontOfficeExplorationPath: "tool/",
-
-
-	/**
-	 * Logger
-	 */
-	// 0 means TRACE and higher. Use when you want to see all messages.
-	// 1 means INFO and higher
-	// 2 means WARN and higher
-	// 3 means ERROR only
-	// 4 means nothing from our application will be displayed. This should be default for production use.
-	// Any other or none means INFO as this is default logging level.
 	loggingLevel: 0,
-
-
-	/**
-	 * Data models - extra types or properties
-	 */
-	models: {
-		place: {
-			description: false
-		}
-	},
 
 };
 

--- a/src/configDefaults.js
+++ b/src/configDefaults.js
@@ -45,7 +45,7 @@ export default {
 	// 3 means ERROR only
 	// 4 means nothing from our application will be displayed. This should be default for production use.
 	// Any other or none means INFO as this is default logging level.
-	loggingLevel: 0,
+	loggingLevel: 4,
 
 
 	/**


### PR DESCRIPTION
Config split in two
1) Defaults 
Common/base values for all instances of Panther. Should only change because of change in architecture or for new config options.
Single variant will exist, managed in project repository (here).
2) Config (rewrites)
Per-instance values, development features, etc. Used as old config.
Multiple variants - one per instance, plus local use. Managed in gisat/docker
Whole config is to be imported, values will be accesed as config.value (as in BE)

Non-breaking (though will result in breaking changes in config.value syntax later)
Defaults are only accessed from config (2), config (2) retains old exports for values currently in use.
